### PR TITLE
v1.1.2 - 29.02.2020

### DIFF
--- a/To Do App 2 React dev changelog.md
+++ b/To Do App 2 React dev changelog.md
@@ -1,5 +1,5 @@
 
-# Struktura state (kopia zapasowa)
+# Struktura state v1
 
 state = {
     lists: [
@@ -18,6 +18,27 @@ state = {
 
 ###############################
 
+# Struktura state v2
+
+state = {
+    lists: [
+      {listId: 1, listName: '2019-12-02 (pon)', listClasses: ['ToDoList__nameBar'],
+      tasks: [
+        { taskId: 132352, taskContent: 'jakieś zadanie', taskClasses: ['taskItem'] },
+        { taskId: 256573, taskContent: 'kolejne zadanie', taskClasses: ['taskItem'] },
+        { taskId: 323278, taskContent: 'jeszcze jedno zadanie', taskClasses: ['taskItem'] }
+      ]},
+      {listId: 2, listName: '2019-12-03 (wt)', listClasses: ['ToDoList__nameBar'],
+      tasks: [
+        { taskId: 178992, taskContent: 'inne zadanie', taskClasses: ['taskItem'] },
+        { taskId: 257321, taskContent: 'następne zadanie', taskClasses: ['taskItem'] },
+        { taskId: 309345, taskContent: 'inne trzecie zadanie', taskClasses: ['taskItem'] }
+      ]}
+    ]
+  }
+
+###############################
+
 # Pomysły na przyszłość / uwagi:
 
 - Nadawanie listom klasy z opacity przy dragOver i usuwaniu jej przy dragEnd, dragLeave i drop. Dodatkowe ograniczenie - sprawdzenie, że jakakolwiek lista na isListDragged=true. Tylko czy warto z tym kombinować? Przy przenoszeniu list trudno o pomyłkę, a zabawa z klasami to dodatkowe generowanie dużej ilości eventów.
@@ -28,23 +49,23 @@ state = {
 
 ###############################
 
-# Refactor
+# To Do:
 
-- rozdzielenie ogólnego state od state dla d'n'd? Może jak w starej wersji nie obiekt z true/false tylko data-attributes dodawane na czas przenoszenia? Przy tymczasowych data attributes trzeba by było zmienić szukanie z id listy czy taska na szukanie, który element ma dany atrybut. Przy eventach może być konieczność użycia e.target.closest i wskazać klasę elementu, który ma dostać data-attribute lub ma on zostać usunięty. Tylko dodanie data-attribute chyba zmienia DOM, więc wiązałoby się to prawdopodobnie z dodatkowymi re-renderami.
-Albo może usunąć całkowicie isElDragged i isElDraggedOver ze state i dodawać je tylko przy konkretnych eventach?
-
-- takie rozbicie Tasks i Lists na komponenty, żeby w React Dev Tools były widoczne listy na wzór zadań.
-
-- zmiana auto-save z pojedynczych funkcji -> useEffect zależne od zmian w myTaskLists + usunięcie localStorage.setItem. Pamiętać, że niektóre eventy d'n'd mają ustawione setMyTasks, więc wtedy mogą sie zapisywać do LS także true nadane w isElDragged i isElDraggedOver.
-
-- textarea zamiast inputa?
-
-- przetestować:
+- Po każdej większej zmianie w kodzie testować:
   - czy na pewno działają wszystkie fn
   - czy poprawnie zmienia się state
   - czy odpowiednie zmiany zapisują się do LS
   - czy otrzymuje się poprawny plik zapisu
   - czy można wczytać ten plik bez problemu
+
+###############################
+
+# Refactor
+
+- Takie rozbicie Tasks i Lists na komponenty, żeby w React Dev Tools były widoczne listy na wzór zadań.
+
+- Zmiana auto-save z pojedynczych funkcji -> useEffect zależne od zmian w myTaskLists + usunięcie localStorage.setItem. Pamiętać, że niektóre eventy d'n'd mają ustawione setMyTasks, więc do LS mogą się zapisywać także tymaczasowe states z d'n'd, a tego lepiej uniknąć.
+
 
 # Chrome Extension
 
@@ -53,6 +74,19 @@ Albo może usunąć całkowicie isElDragged i isElDraggedOver ze state i dodawa�
 ###############################
 
 # Changelog
+
+++++++++++++++++++++++++
+
+### v1.1.2 - 29.02.2020
+
+Dalsze zmiany w drag and drop lists i tasks:
+
+1. Zostawienie setMyTaskLists tylko w tych eventach, gdzie to konieczne.
+2. Usunięcie ze state oraz z tworzenia nowych list i tasków key: value pairs -> isListDragged, isListDraggedOver, isTaskDragged, isTaskDraggedOver.
+3. Zastąpienie powyższych tymczasowymi key: value pairs, które nie będą przechowywane w state i będą tylko dodawane/usuwane podczas drag and drop -> draggedList, draggedOverList, draggedTask, draggedOverTask.
+4. Jeśli ktoś korzysta z tej listy, to warto dla porządku stworzyć plik z backupem, edytować go i usunąć zbędne elementy z pkt. 2, a następnie go wczytać. Choć przy braku zmian też wszystko będzie działało prawidłowo jak do tej pory.
+5. Dodano dodatkowe if statement do taskDragLeaveHandler wykorzystujące szukanie regexa w event.relatedTarget.classList.value, żeby sprawdzić, czy dragLeave następuje wewnątrz taska. Jeśli test da false, to wtedy po przejściu np. na nazwę listy czy gdzieś poza listę zniknie klasa .draggedOverItem z taska, na którym do tej pory zostawała i task był oznaczony jako draggedOver do momentu oznaczenia tak innego taska.
+Z kolei drugi if działa w sposób opisany w v1.1.0, czyli tylko z setTimeout taskDragLeaveHandler nie czyści od razu klasy draggedOverItem jeśli dragOver event jest odpalany w obrębie jednego taska. Bez setTimeout elementy draggedOver nie zmieniały w ogóle koloru.
 
 ++++++++++++++++++++++++
 

--- a/src/components/lists/ToDoLists.jsx
+++ b/src/components/lists/ToDoLists.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import './scss/ToDoLists.css';
 import { ToDoContext } from '../../contexts/ToDoContext';
 import Task from '../tasks/Tasks';
-import { listDragStartHandler, listDragEndHandler, listDragOverHandler, listDragLeaveHandler, listDropHandler } from './listsDragAndDrop';
+import { listDragStartHandler, clearDragAndDropStates, listDragOverHandler, listDragLeaveHandler, listDropHandler } from './listsDragAndDrop';
 
 const ToDoLists = () => {
   const { myTaskLists, setMyTaskLists } = useContext(ToDoContext);
@@ -11,8 +11,6 @@ const ToDoLists = () => {
     taskId: new Date().getTime(),
     taskContent: '',
     taskClasses: ['taskItem', 'spanEdit--task'],
-    isTaskDragged: false,
-    isTaskDraggedOver: false,
   };
 
   const addTaskFirst = (listId) => {
@@ -71,7 +69,7 @@ const ToDoLists = () => {
   };
 
   const taskLists = myTaskLists.map(list => (
-    <div className="ToDoList__container" draggable="true" key={list.listId} onDragStart={() => listDragStartHandler(list.listId, event, myTaskLists, setMyTaskLists)} onDragEnd={() => listDragEndHandler(myTaskLists, setMyTaskLists)} onDragOver={() => listDragOverHandler(list.listId, event, myTaskLists)} onDragLeave={() => listDragLeaveHandler(list.listId, myTaskLists, setMyTaskLists)} onDrop={() => listDropHandler(myTaskLists, setMyTaskLists)}>
+    <div className="ToDoList__container" draggable="true" key={list.listId} onDragStart={() => listDragStartHandler(list.listId, event, myTaskLists, setMyTaskLists)} onDragEnd={() => clearDragAndDropStates(myTaskLists, setMyTaskLists)} onDragOver={() => listDragOverHandler(list.listId, event, myTaskLists)} onDragLeave={() => listDragLeaveHandler(list.listId, myTaskLists)} onDrop={() => listDropHandler(event, myTaskLists, setMyTaskLists)}>
       <div className={list.listClasses.join(' ')}>
         <input type="button" className="defaultButton addTaskBtn addTaskBtn--first" value="&#x02A72;" onClick={() => addTaskFirst(list.listId)} />
         <input type="button" className="defaultButton addTaskBtn addTaskBtn--last" value="&#x2A71;" onClick={() => addTaskLast(list.listId)} />

--- a/src/components/lists/listsDragAndDrop.js
+++ b/src/components/lists/listsDragAndDrop.js
@@ -6,26 +6,34 @@ export const listDragStartHandler = (listId, event, myTaskLists, setMyTaskLists)
     event.dataTransfer.setData('text', listId);
     const newListsArray = myTaskLists.slice();
     const draggedListIndex = newListsArray.findIndex(el => el.listId === listId);
-    newListsArray[draggedListIndex].isListDragged = true;
+    newListsArray[draggedListIndex].draggedList = true;
     setMyTaskLists(newListsArray);
   }
 };
 
-export const listDragEndHandler = (myTaskLists, setMyTaskLists) => {
+export const clearDragAndDropStates = (myTaskLists, setMyTaskLists) => {
   const newListsArray = myTaskLists.map(list => {
     const listDragStateReset = list;
     listDragStateReset.tasks.map(task => {
       const taskDragStateReset = task;
-      taskDragStateReset.isTaskDragged = false;
-      taskDragStateReset.isTaskDraggedOver = false;
+      if (taskDragStateReset.draggedTask) {
+        delete taskDragStateReset.draggedTask;
+      }
+      if (taskDragStateReset.draggedOverTask) {
+        delete taskDragStateReset.draggedOverTask;
+      }
       if (taskDragStateReset.taskClasses.find(el => el === 'draggedOverItem')) {
         const classToRemoveIndex = taskDragStateReset.taskClasses.findIndex(el => el === 'draggedOverItem');
         taskDragStateReset.taskClasses.splice(classToRemoveIndex, 1);
       }
       return taskDragStateReset;
     });
-    listDragStateReset.isListDragged = false;
-    listDragStateReset.isListDraggedOver = false;
+    if (listDragStateReset.draggedList) {
+      delete listDragStateReset.draggedList;
+    }
+    if (listDragStateReset.draggedOverList) {
+      delete listDragStateReset.draggedOverList;
+    }
     return listDragStateReset;
   });
   setMyTaskLists(newListsArray);
@@ -35,45 +43,45 @@ export const listDragOverHandler = (listId, event, myTaskLists) => {
   event.preventDefault();
   const newListsArray = myTaskLists.slice();
   const draggedOverListIndex = newListsArray.findIndex(el => el.listId === listId);
-  newListsArray[draggedOverListIndex].isListDraggedOver = true;
+  newListsArray[draggedOverListIndex].draggedOverList = true;
 };
 
-export const listDragLeaveHandler = (listId, myTaskLists, setMyTaskLists) => {
+export const listDragLeaveHandler = (listId, myTaskLists) => {
   const newListsArray = myTaskLists.slice();
   const dragLeftListIndex = newListsArray.findIndex(el => el.listId === listId);
-  newListsArray[dragLeftListIndex].isListDraggedOver = false;
-  setMyTaskLists(newListsArray);
+  delete newListsArray[dragLeftListIndex].draggedOverList;
 };
 
-export const listDropHandler = (myTaskLists, setMyTaskLists) => {
+export const listDropHandler = (event, myTaskLists, setMyTaskLists) => {
+  event.preventDefault();
   const newListsArray = myTaskLists.slice();
 
   // drop list on other list or on task on other list
-  if (newListsArray.find(list => list.isListDragged === true)) {
-    const droppedListIndex = newListsArray.findIndex(list => list.isListDragged === true);
-    const droppedList = newListsArray[droppedListIndex];
-    const draggedOverListIndex = newListsArray.findIndex(list => list.isListDraggedOver === true);
+  if (newListsArray.find(list => list.draggedList)) {
+    const draggedListIndex = newListsArray.findIndex(list => list.draggedList);
+    const draggedList = newListsArray[draggedListIndex];
+    const draggedOverListIndex = newListsArray.findIndex(list => list.draggedOverList);
 
-    if (droppedListIndex !== draggedOverListIndex) {
-      newListsArray.splice(droppedListIndex, 1);
-      newListsArray.splice(draggedOverListIndex, 0, droppedList);
-      listDragEndHandler(myTaskLists, setMyTaskLists);
+    if (draggedListIndex !== draggedOverListIndex) {
+      newListsArray.splice(draggedListIndex, 1);
+      newListsArray.splice(draggedOverListIndex, 0, draggedList);
+      clearDragAndDropStates(myTaskLists, setMyTaskLists);
       setMyTaskLists(newListsArray);
       localStorage.setItem('myReactTasks', (JSON.stringify(newListsArray)));
     }
   }
 
   // drop task on the list (not on other task)
-  if (!newListsArray.find(list => list.isListDragged === true) && newListsArray.find(list => list.tasks.some(task => task.isTaskDragged === true)) && !newListsArray.find(list => list.tasks.some(task => task.isTaskDraggedOver === true))) {
-    const droppedTask = newListsArray.find(list => list.tasks.some(task => task.isTaskDragged === true)).tasks.find(task => task.isTaskDragged === true);
-    const droppedTaskIndex = newListsArray.find(list => list.tasks.some(task => task.isTaskDragged === true)).tasks.findIndex(task => task.isTaskDragged === true);
-    const droppedTaskFromListIndex = newListsArray.findIndex(list => list.tasks.some(task => task.isTaskDragged === true));
-    const droppedTaskOnListIndex = newListsArray.findIndex(list => list.isListDraggedOver === true);
+  if (!newListsArray.find(list => list.draggedList) && newListsArray.find(list => list.tasks.some(task => task.draggedTask)) && !newListsArray.find(list => list.tasks.some(task => task.draggedOverTask))) {
+    const draggedTaskItem = newListsArray.find(list => list.tasks.some(task => task.draggedTask)).tasks.find(task => task.draggedTask);
+    const draggedTaskIndex = newListsArray.find(list => list.tasks.some(task => task.draggedTask)).tasks.findIndex(task => task.draggedTask);
+    const draggedTaskFromListIndex = newListsArray.findIndex(list => list.tasks.some(task => task.draggedTask));
+    const droppedTaskOnListIndex = newListsArray.findIndex(list => list.draggedOverList);
 
-    newListsArray[droppedTaskFromListIndex].tasks.splice(droppedTaskIndex, 1);
-    newListsArray[droppedTaskOnListIndex].tasks.push(droppedTask);
-    newListsArray[droppedTaskOnListIndex].isListDraggedOver = false;
-    droppedTask.isTaskDragged = false;
+    newListsArray[draggedTaskFromListIndex].tasks.splice(draggedTaskIndex, 1);
+    newListsArray[droppedTaskOnListIndex].tasks.push(draggedTaskItem);
+    delete newListsArray[droppedTaskOnListIndex].draggedOverList;
+    delete draggedTaskItem.draggedTask;
     setMyTaskLists(newListsArray);
     localStorage.setItem('myReactTasks', (JSON.stringify(newListsArray)));
   }

--- a/src/components/main-controls/MainControls.jsx
+++ b/src/components/main-controls/MainControls.jsx
@@ -14,8 +14,6 @@ const MainControls = () => {
         listId: new Date().getTime(),
         listName: dateInput + ' (' + dayName[realDate.getDay()] + ')',
         listClasses: ['ToDoList__nameBar'],
-        isListDragged: false,
-        isListDraggedOver: false,
         tasks: [],
       };
       const newListsArray = [...myTaskLists, list];

--- a/src/components/tasks/Tasks.jsx
+++ b/src/components/tasks/Tasks.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { ToDoContext } from '../../contexts/ToDoContext';
 import './scss/Tasks.css';
-import { taskDragStartHandler, taskDragEndHandler, taskDragOverHandler, taskDragLeaveHandler, taskDropHandler } from './tasksDragAndDrop';
+import { taskDragStartHandler, clearDragAndDropStates, taskDragOverHandler, taskDragLeaveHandler, taskDropHandler } from './tasksDragAndDrop';
 
 const Task = (task) => {
   const { myTaskLists, setMyTaskLists } = useContext(ToDoContext);
@@ -70,7 +70,7 @@ const Task = (task) => {
   };
 
   return (
-    <div className={task.taskClasses.join(' ')} draggable="true" onDragStart={() => taskDragStartHandler(task.taskId, event, myTaskLists, setMyTaskLists)} onDragEnd={() => taskDragEndHandler(myTaskLists, setMyTaskLists)} onDragOver={() => taskDragOverHandler(task.taskId, event, myTaskLists)} onDragLeave={() => taskDragLeaveHandler(task.taskId, myTaskLists, setMyTaskLists)} onDrop={() => taskDropHandler(myTaskLists, setMyTaskLists)}>
+    <div className={task.taskClasses.join(' ')} draggable="true" onDragStart={() => taskDragStartHandler(task.taskId, event, myTaskLists, setMyTaskLists)} onDragEnd={() => clearDragAndDropStates(myTaskLists, setMyTaskLists)} onDragOver={() => taskDragOverHandler(task.taskId, event, myTaskLists)} onDragLeave={() => taskDragLeaveHandler(task.taskId, event, myTaskLists, setMyTaskLists)} onDrop={() => taskDropHandler(event, myTaskLists, setMyTaskLists)}>
       <div className="taskControlBtns">
         <input className="defaultButton prioBtn" type="button" value="P" onClick={() => prioTask(task.taskId)} />
         <input className="defaultButton taskInProgressBtn" type="button" value="&#128336;" onClick={() => taskInProgress(task.taskId)} />


### PR DESCRIPTION
Dalsze zmiany w drag and drop lists i tasks:

1. Zostawienie setMyTaskLists tylko w tych eventach, gdzie to konieczne.
2. Usunięcie ze state oraz z tworzenia nowych list i tasków key: value pairs -> isListDragged, isListDraggedOver, isTaskDragged, isTaskDraggedOver.
3. Zastąpienie powyższych tymczasowymi key: value pairs, które nie będą przechowywane w state i będą tylko dodawane/usuwane podczas drag and drop -> draggedList, draggedOverList, draggedTask, draggedOverTask.
4. Jeśli ktoś korzysta z tej listy, to warto dla porządku stworzyć plik z backupem, edytować go i usunąć zbędne elementy z pkt. 2, a następnie go wczytać. Choć przy braku zmian też wszystko będzie działało prawidłowo jak do tej pory.
5. Dodano dodatkowe if statement do taskDragLeaveHandler wykorzystujące szukanie regexa w event.relatedTarget.classList.value, żeby sprawdzić, czy dragLeave następuje wewnątrz taska. Jeśli test da false, to wtedy po przejściu np. na nazwę listy czy gdzieś poza listę zniknie klasa .draggedOverItem z taska, na którym do tej pory zostawała i task był oznaczony jako draggedOver do momentu oznaczenia tak innego taska.
Z kolei drugi if działa w sposób opisany w v1.1.0, czyli tylko z setTimeout taskDragLeaveHandler nie czyści od razu klasy draggedOverItem jeśli dragOver event jest odpalany w obrębie jednego taska. Bez setTimeout elementy draggedOver nie zmieniały w ogóle koloru.